### PR TITLE
Removed reference to Rickshaw and CyclusJS from The Cyclus Ecosystem

### DIFF
--- a/source/cep/cep3.rst
+++ b/source/cep/cep3.rst
@@ -29,12 +29,6 @@ stable.)  The projects that are under the release manager's purview are:
 * `Cycamore`_
 * `Cymetric`_
 
-The projects which are not yet under the release managers purview are:
-
-* `Rickshaw`_
-* `CyclusJS`_
-
-
 .. note::
 
     The following full release process only applies to MAJOR and MINOR


### PR DESCRIPTION
CEP 3 used to refer to Rickshaw and CyclusJS, which it was agreed were no longer relevant for the core cyclus ecosystem (needed for release), so reference to them was removed from the "The Cyclus Ecosystem" section of CEP 3.